### PR TITLE
Clientside pool fix

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1309,9 +1309,9 @@ function stateMachine() {
             }
             pagePool.push(page);
         });
-        if (specification.numPages > 0) {
+        if (specification.poolSize > 0) {
             specification.randomiseOrder = true;
-            pagePool = pickSubPool(pagePool, specification.numPages);
+            pagePool = pickSubPool(pagePool, specification.poolSize);
         }
 
         // Now get the order of pages


### PR DESCRIPTION
Wrong variable name is used. Specifying `numPages` is not allowed by the XML definition.

With this fix, client-side pooling is now working.

Fixes:
#295
#292 (partially, doesn't change server side pooling)