### PR TITLE
Fix improper pooling (on server)

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -1332,6 +1332,7 @@ function stateMachine() {
         fixed.forEach(function (page) {
             pagePool.splice(page.position, 0, page);
         });
+        pagePool.splice(specification.poolSize);
 
         // Now process the pages
         pagePool.forEach(function (page, i) {


### PR DESCRIPTION
Ignores pages after `poolSize` of setup.

Relative to #295 #292 #303